### PR TITLE
Issue 27 cache splits on disk

### DIFF
--- a/greenguard/pipeline.py
+++ b/greenguard/pipeline.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import gc
 import json
 import logging
 import os
@@ -314,6 +315,8 @@ class GreenGuardPipeline(object):
                 pickle.dump((fold, pipeline, fit, predict, y_test, static), split_file)
 
             splits.append(export_path)
+            del fold, pipeline, fit, predict, y_test
+            gc.collect()
 
         return splits
 

--- a/greenguard/pipeline.py
+++ b/greenguard/pipeline.py
@@ -386,14 +386,15 @@ class GreenGuardPipeline(object):
 
     def _make_btb_scorer(self, target_times, readings, turbines):
         splits = {}
-        for name in self._template_names:
-            splits[name] = self._generate_splits(name, target_times, readings, turbines)
-
-        del target_times, readings, turbines
-        gc.collect()
 
         def scorer(template_name, config):
             template_splits = splits.get(template_name)
+            if template_splits is None:
+                template_splits = self._generate_splits(
+                    template_name, target_times, readings, turbines)
+
+                splits[template_name] = template_splits
+
             cv_score = self._cross_validate(template_splits, config)
             if self._is_better(cv_score):
                 _config = '\n'.join('      {}: {}'.format(n, v) for n, v in config.items())

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ development_requires = [
 
     # style check
     'flake8>=3.7.7',
-    'isort>=4.3.4',
+    'isort>=4.3.4,<5',
 
     # fix style issues
     'autoflake>=1.2',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ except IOError:
 
 install_requires = [
     'mlblocks>=0.3.4,<0.4',
+    'Keras>=2.1.6,<2.4',
     'mlprimitives>=0.2.4,<0.3',
     'scipy>=1.0.1,<1.4.0',
     'baytune>=0.3.9,<0.4',


### PR DESCRIPTION
Resolve #27 
- If `cache_path` is given, cache the generated cross validation splits in that folder.
- Patched Keras to be saved on disk without a model trained. This is needed for the LSTM pipelines.